### PR TITLE
Allow inclusion of the voicemail file with notification emails

### DIFF
--- a/callattendant/app.cfg.example
+++ b/callattendant/app.cfg.example
@@ -213,6 +213,8 @@ EMAIL_SERVER_USERNAME = 'user name to log into the SMTP server'
 EMAIL_SERVER_PASSWORD = 'password to log into the SMTP server'
 EMAIL_FROM = 'e-mail address to appear in the "From:" header'
 EMAIL_TO = 'e-mail address(es) to send the voicemail notification to, one string, comma-separated'
+# Set EMAIL_ATTACH to True to include the voicemail wave file with the notification email.
+EMAIL_ATTACH = False
 
 # GPIO_LED_..._PIN: These values are the GPIO pin numbers attached to the LED indicators
 # GPIO_LED_..._BRIGHTNESS: These values are a percentage of brightness for the LED indicators when on.

--- a/callattendant/messaging/voicemail.py
+++ b/callattendant/messaging/voicemail.py
@@ -156,20 +156,7 @@ class VoiceMail:
 
             # Send an e-mail notification
             if self.config["EMAIL_ENABLE"]:
-                context = ssl.create_default_context()
-                with smtplib.SMTP_SSL(self.config["EMAIL_SERVER"], self.config["EMAIL_PORT"], context=context) as server:
-                    server.login(self.config["EMAIL_SERVER_USERNAME"], self.config["EMAIL_SERVER_PASSWORD"])
-                    message = MIMEMultipart()
-                    message['Subject'] = 'Phone message recorded'
-                    message['From'] = self.config["EMAIL_FROM"]
-                    message['To'] = self.config["EMAIL_TO"]
-                    body = MIMEText(f'Caller {caller["NMBR"]}, {caller["NAME"]} left a message.\n')
-                    message.attach(body)
-                    with open(filepath, 'rb') as wavefile:
-                        att = MIMEAudio(wavefile.read(), 'wave')
-                        att.add_header('Content-Disposition', f'attachment;filename={os.path.basename(filepath)}')
-                        message.attach(att)
-                    server.sendmail(self.config["EMAIL_FROM"], self.config["EMAIL_TO"].split(','), message.as_string())
+                self.__send_email(caller, filepath)
 
             # Return the messageID on success
             return msg_no
@@ -177,6 +164,23 @@ class VoiceMail:
             self.reset_message_indicator()
             # Return failure
             return None
+
+    def __send_email(self, caller, filepath):
+        context = ssl.create_default_context()
+        with smtplib.SMTP_SSL(self.config["EMAIL_SERVER"], self.config["EMAIL_PORT"], context=context) as server:
+            server.login(self.config["EMAIL_SERVER_USERNAME"], self.config["EMAIL_SERVER_PASSWORD"])
+            message = MIMEMultipart()
+            message['Subject'] = 'Phone message recorded'
+            message['From'] = self.config["EMAIL_FROM"]
+            message['To'] = self.config["EMAIL_TO"]
+            body = MIMEText(f'Caller {caller["NMBR"]}, {caller["NAME"]} left a message.\n')
+            message.attach(body)
+            if self.config["EMAIL_ATTACH"]:
+                with open(filepath, 'rb') as wavefile:
+                    att = MIMEAudio(wavefile.read(), 'wave')
+                    att.add_header('Content-Disposition', f'attachment;filename={os.path.basename(filepath)}')
+                    message.attach(att)
+            server.sendmail(self.config["EMAIL_FROM"], self.config["EMAIL_TO"].split(','), message.as_string())
 
     def delete_message(self, msg_no):
         """

--- a/callattendant/messaging/voicemail.py
+++ b/callattendant/messaging/voicemail.py
@@ -23,6 +23,9 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #  SOFTWARE.
 
+from email.mime.audio import MIMEAudio
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
 import os
 import threading
 from datetime import datetime
@@ -150,20 +153,24 @@ class VoiceMail:
         if self.modem.record_audio(filepath, detect_silence):
             # Save to Message table (message.add will update the indicator)
             msg_no = self.messages.add(call_no, filepath)
-            
+
             # Send an e-mail notification
             if self.config["EMAIL_ENABLE"]:
                 context = ssl.create_default_context()
                 with smtplib.SMTP_SSL(self.config["EMAIL_SERVER"], self.config["EMAIL_PORT"], context=context) as server:
                     server.login(self.config["EMAIL_SERVER_USERNAME"], self.config["EMAIL_SERVER_PASSWORD"])
-                    message = f"""Subject: Phone  message recorded
-From: {self.config["EMAIL_FROM"]}
-To: {self.config["EMAIL_TO"]}
+                    message = MIMEMultipart()
+                    message['Subject'] = 'Phone message recorded'
+                    message['From'] = self.config["EMAIL_FROM"]
+                    message['To'] = self.config["EMAIL_TO"]
+                    body = MIMEText(f'Caller {caller["NMBR"]}, {caller["NAME"]} left a message.\n')
+                    message.attach(body)
+                    with open(filepath, 'rb') as wavefile:
+                        att = MIMEAudio(wavefile.read(), 'wave')
+                        att.add_header('Content-Disposition', f'attachment;filename={os.path.basename(filepath)}')
+                        message.attach(att)
+                    server.sendmail(self.config["EMAIL_FROM"], self.config["EMAIL_TO"].split(','), message.as_string())
 
-Caller {caller["NMBR"]}, {caller["NAME"]} left a message.
-"""
-                    server.sendmail(self.config["EMAIL_FROM"], self.config["EMAIL_TO"].split(','), message)
-            
             # Return the messageID on success
             return msg_no
         else:


### PR DESCRIPTION
With the `EMAIL_ATTACH` configuration flag set, this change includes the wave file when sending notification emails. It is largely inspired by [this SO question](https://stackoverflow.com/q/1966073/5403337).

My friend was able to verify that it works on his Raspberry Pi. Unfortunately I don't have one, so I'm not able to run the unit tests. If someone could add a simple test before merging, that would probably be ideal 🙏